### PR TITLE
Changed the brackets used for version parameters and arguments

### DIFF
--- a/batakjava/syntax/Batakjava.flex
+++ b/batakjava/syntax/Batakjava.flex
@@ -1,4 +1,6 @@
 <YYINITIAL> {
   "ver"               { return sym(Terminals.VER); }
   "#"                 { return sym(Terminals.SHARP); }
+  "«"                 { return sym(Terminals.LGUI); }
+  "»"                 { return sym(Terminals.RGUI); }
 }

--- a/batakjava/syntax/Batakjava.parser
+++ b/batakjava/syntax/Batakjava.parser
@@ -1,17 +1,17 @@
 ClassDecl class_declaration =
     modifiers.m? CLASS IDENTIFIER VER version_number.v super.s? interfaces.i? class_body.b
       {: return new VersionClassDecl(new Modifiers(m), IDENTIFIER, s, i, b, v); :}
-  | modifiers.m? CLASS IDENTIFIER VER version_number.v GT version_parameters.p LT super.s?
+  | modifiers.m? CLASS IDENTIFIER VER version_number.v LGUI version_parameters.p RGUI super.s?
     interfaces.i? class_body.b
       {: return new GenericVersionClassDecl(new Modifiers(m), IDENTIFIER, s, i, b, v, p); :}
   ;
 
 Access class_or_interface_type =
-    name.n GT version_arguments.v LT
+    name.n LGUI version_arguments.v RGUI
       {: return new ParVersionTypeAccess(n, v); :}
   | name.n SHARP version_arguments.v SHARP
       {: return new VersionTypeAccess(n, v); :}
-  | name.n SHARP version_arguments.va SHARP GT version_arguments.vb LT
+  | name.n SHARP version_arguments.va SHARP LGUI version_arguments.vb RGUI
       {: return new ParVersionTypeAccess(new VersionTypeAccess(n, va), vb); :}
   ;
 

--- a/batakjava/syntax/BatakjavaMethods.parser
+++ b/batakjava/syntax/BatakjavaMethods.parser
@@ -1,18 +1,18 @@
 MethodDecl method_header =
-    modifiers.m? GT version_parameters.l LT type.t IDENTIFIER LPAREN formal_parameter_list.p? RPAREN dims.d? throws.tl?
+    modifiers.m? LGUI version_parameters.l RGUI type.t IDENTIFIER LPAREN formal_parameter_list.p? RPAREN dims.d? throws.tl?
     {: return new GenericVersionMethodDecl(new Modifiers(m), t.addArrayDims(d), IDENTIFIER, p, tl, new Opt(), l); :}
-  | modifiers.m? GT version_parameters.l LT VOID IDENTIFIER LPAREN formal_parameter_list.p? RPAREN throws.tl?
+  | modifiers.m? LGUI version_parameters.l RGUI VOID IDENTIFIER LPAREN formal_parameter_list.p? RPAREN throws.tl?
     {: return new GenericVersionMethodDecl(new Modifiers(m), new PrimitiveTypeAccess("void"), IDENTIFIER, p, tl, new Opt(), l); :}
   ;
 Access method_invocation =
-    primary.p DOT GT version_arguments.v LT IDENTIFIER LPAREN argument_list.l? RPAREN
+    primary.p DOT LGUI version_arguments.v RGUI IDENTIFIER LPAREN argument_list.l? RPAREN
       {: return p.qualifiesAccess(new ParVersionMethodAccess(IDENTIFIER, l, v)); :}
-  | name.n DOT GT version_arguments.v LT IDENTIFIER LPAREN argument_list.l? RPAREN 
+  | name.n DOT LGUI version_arguments.v RGUI IDENTIFIER LPAREN argument_list.l? RPAREN 
     {: return n.qualifiesAccess(new ParVersionMethodAccess(IDENTIFIER, l, v));  :}
-  | SUPER DOT GT version_arguments.v LT IDENTIFIER LPAREN argument_list.l? RPAREN 
+  | SUPER DOT LGUI version_arguments.v RGUI IDENTIFIER LPAREN argument_list.l? RPAREN 
     {: return new SuperAccess().qualifiesAccess(
                         new ParVersionMethodAccess(IDENTIFIER, l, v));  :}
-  | name.n DOT.d1 SUPER DOT.d2 GT version_arguments.v LT IDENTIFIER LPAREN argument_list.l? RPAREN 
+  | name.n DOT.d1 SUPER DOT.d2 LGUI version_arguments.v RGUI IDENTIFIER LPAREN argument_list.l? RPAREN 
     {: return n.qualifiesAccess(new SuperAccess()).qualifiesAccess(
                             new ParVersionMethodAccess(IDENTIFIER, l, v));  :}
   ;

--- a/tests/syntax/Test_02.java
+++ b/tests/syntax/Test_02.java
@@ -3,8 +3,8 @@ public class Test_02 ver 1 {
   public static void main(String[] args) {
     new Test_02#1#();
     new Test_02#1,2#();
-    new Test_02>V<();
-    new Test_02>V,W<();
+    new Test_02«V»();
+    new Test_02«V,W»();
   }
 
 }

--- a/tests/syntax/Test_03.java
+++ b/tests/syntax/Test_03.java
@@ -1,3 +1,3 @@
-public class Test_03 ver 1 >V,W< {
+public class Test_03 ver 1 «V,W» {
   
 }

--- a/tests/syntax/Test_04.java
+++ b/tests/syntax/Test_04.java
@@ -1,8 +1,8 @@
-public class Test_04 ver 1 >V< {
+public class Test_04 ver 1 «V» {
   public static void main(String[] args) {
-    new Test_04>1<();
-    new Test_04#1#>1<();
-    new Test_04>1,2<();
-    new Test_04#1,2#>1,2<(); 
+    new Test_04«1»();
+    new Test_04#1#«1»();
+    new Test_04«1,2»();
+    new Test_04#1,2#«1,2»(); 
   }
 }

--- a/tests/syntax/Test_05.java
+++ b/tests/syntax/Test_05.java
@@ -1,8 +1,8 @@
-public class Test_05 ver 1 >V,W< {
-  public Test_05>V< m() {
-    return new Test_05>V<();
+public class Test_05 ver 1 «V,W» {
+  public Test_05«V» m() {
+    return new Test_05«V»();
   }
-  public Test_05>V,W< o() {
-    return new Test_05>V,W<();
+  public Test_05«V,W» o() {
+    return new Test_05«V,W»();
   }
 }

--- a/tests/syntax/Test_06.java
+++ b/tests/syntax/Test_06.java
@@ -1,5 +1,5 @@
-public class Test_06 ver 1 >V< {
-  public >W< Test_06>W< m(Test_06>W< t) {
+public class Test_06 ver 1 «V» {
+  public «W» Test_06«W» m(Test_06«W» t) {
     return t;
   }
 }

--- a/tests/syntax/Test_07.java
+++ b/tests/syntax/Test_07.java
@@ -1,8 +1,8 @@
 public class Test_08 ver 1 {
   public static void main(String[] args) {
-    new Object().>V<m();
-    super.>V<m();
-    Object.>V<m();
-    Object.super.>V<m(); 
+    new Object().«V»m();
+    super.«V»m();
+    Object.«V»m();
+    Object.super.«V»m(); 
   }
 }

--- a/tests/syntax/build.sh
+++ b/tests/syntax/build.sh
@@ -1,3 +1,3 @@
 #/bin/sh
 
-java -cp pbatakjava.jar org.extendj.JavaDumpTree tests/syntax/*
+java -cp pbatakjava.jar org.extendj.JavaDumpTree tests/syntax/*.java


### PR DESCRIPTION
Replaced <> with «» for version parameters and arguments.