### PR TITLE
Abstract all versioned class instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 /tests/method_04/class
 /tests/subtype_01/class
 /tests/hash_01/class
+/tests/hash_02/class
 
 /tests/output
 

--- a/batakjava/backend/Compilation.jrag
+++ b/batakjava/backend/Compilation.jrag
@@ -27,6 +27,7 @@ aspect Generation {
             TypeDecl oldFactory = generated.findInterface(newInterface.packageName(), newInterface.name() + "_Factory");
 
             for (BodyDecl newMethod: newInterface.getBodyDeclList()) {
+              //System.err.println(newMethod.prettyPrint());
               oldInterface.addBodyDecl(newMethod.treeCopy());
             }
 
@@ -59,14 +60,15 @@ aspect Generation {
 
     for (String name: names) {
       generated.removeDuplicate(name);
-      generated.processMethods(name);
+      generated.removeDuplicate(name + "_Factory");
+      generated.processMethod(name);
       generated.processConstructor(name);
     }
 
     return generated;
   }
 
-  public void Program.processMethods(String name) {
+  public void Program.processMethod(String name) {
     TypeDecl parent = findInterface(name);
     SimpleSet<TypeDecl> classSet = findClassSet(name);
     for (TypeDecl t: classSet) {
@@ -101,7 +103,7 @@ aspect Generation {
   }
 
   public void Program.removeDuplicate(String name) {
-    TypeDecl t = findInterface(name + "_Factory");
+    TypeDecl t = findInterface(name);
     List<BodyDecl> withoutDuplicate = new List();
     java.util.Set<String> signatures = new HashSet();
     for (BodyDecl b: t.getBodyDeclList()) {
@@ -125,7 +127,6 @@ aspect Generation {
   
   syn nta List<TypeDecl> TypeDecl.compileInterface() = new List();
 
-  // TODO: handle different constructors in different versions
   eq VersionClassDecl.compileInterface() {
     List<TypeDecl> types = new List();
     List<BodyDecl> bodyList = new List();
@@ -167,7 +168,7 @@ aspect Generation {
       bodyList = bodyList.add(body.compile());
     }
 
-    Opt<Access> superAccess = hasSuperClass() ? new Opt(getSuperClass().compileAccess()) : new Opt();
+    Opt<Access> superAccess = hasSuperClass() ? new Opt(getSuperClass().compileInstanceAccess()) : new Opt();
 
     types = types.add(new ClassDecl(
       getModifiers(),
@@ -183,7 +184,7 @@ aspect Generation {
     List<TypeDecl> types = new List();
     List<BodyDecl> bodyList = new List();
 
-    if (this instanceof GenericVersionClassDecl) {
+    if (isGenericVersionClassDecl()) {
       GenericVersionClassDecl thisType = (GenericVersionClassDecl) this;
       for (VersionVariable v: thisType.getVersionVariableList()) {
         TypeAccess typeAccess = v.typeAccess();
@@ -203,7 +204,7 @@ aspect Generation {
     }
 
     Opt<Access> superAccess = hasSuperClass() 
-      ? new Opt(getSuperClass().compileAccess()) : new Opt();
+      ? new Opt(getSuperClass().compileInstanceAccess()) : new Opt();
 
     types = types.add(new ClassDecl(
       getModifiers(),
@@ -244,7 +245,7 @@ aspect Generation {
     List<Stmt> blockStmtList = new List();
 
     // TODO: get rid of instanceof from here
-    if (hostType() instanceof GenericVersionClassDecl) {
+    if (hostType().isGenericVersionClassDecl()) {
       GenericVersionClassDecl host = (GenericVersionClassDecl) hostType();
       for (int i = 0; i < host.getNumVersionVariable(); i++) {
         VersionVariable v_i = host.getVersionVariable(i);
@@ -350,6 +351,28 @@ aspect Generation {
 
   syn nta List<BodyDecl> BodyDecl.compileInterface() = new List();
 
+  eq MethodDecl.compileInterface() {
+    if (getID().equals("main")) {
+      return new List();
+    }
+
+    List<ParameterDeclaration> ps = new List();
+
+    for (ParameterDeclaration p: getParameterList()) {
+      ParameterDeclaration np = new ParameterDeclaration(
+        p.getModifiers(), p.getTypeAccess().compileAccess(), p.getID());
+      ps = ps.add(np);
+    }
+
+    return new List().add(new MethodDecl(
+      getModifiers(),
+      getTypeAccess().compileAccess(),
+      getID(),
+      ps,
+      new List(),
+      new Opt()));
+  }
+
   eq GenericVersionMethodDecl.compileInterface() {
     List<ParameterDeclaration> ps = new List();
     
@@ -384,6 +407,8 @@ aspect Generation {
 
   eq Dot.compileAccess() = new Dot(getLeft().compileExpr(), getRight().compileAccess());
 
+  // TODO: abstract every versioned class?
+  /*
   eq TypeAccess.compileAccess() {
     TypeDecl type = program().typeMap.get(
       new Integer(model().evaluate(solverConst, false).toString()));
@@ -394,11 +419,14 @@ aspect Generation {
   }
   
   eq VersionTypeAccess.compileAccess() {
-    if (getVersionArgument() instanceof VersionVarArgument) {
+    if (getVersionArgument().isVersionVarArgument()) {
       return getTypeAccess().treeCopy();
     }
     return getTypeAccess().compileAccess();
   }
+  */
+
+  eq VersionTypeAccess.compileAccess() = getTypeAccess().compileAccess();
 
   eq ParVersionTypeAccess.compileAccess() = getTypeAccess().compileAccess();
 
@@ -421,13 +449,13 @@ aspect Generation {
         VersionArgument va = getVersionArgument(i);
         TypeAccess compileAccess = vv.typeAccess();
         // TODO: handle version variable argument
-        if (va instanceof VersionNumArgument) {
+        if (va.isVersionNumArgument()) {
           argList = argList.add(new ClassInstanceExpr(
             new TypeAccess(compileAccess.getPackage(),
                            compileAccess.getID() + "_v" + va.getID() + "_Factory"),
             new List()
           ));
-        } else if (va instanceof VersionVarArgument) {
+        } else if (va.isVersionVarArgument()) {
           argList = argList.add(new VarAccess(va.getID()));
         }
         i++;
@@ -456,6 +484,26 @@ aspect Generation {
     }
     return new Block(stmtList);
   }
+
+  syn Access Access.compileInstanceAccess() = treeCopy();
+
+  eq TypeAccess.compileInstanceAccess() {
+    TypeDecl type = getSolution();
+    if (type.isVersioned()) {
+      return new TypeAccess(getPackage(), type.getID() + "_v" + type.version());
+    }
+    return treeCopy();
+  }
+
+  eq VersionTypeAccess.compileInstanceAccess() {
+    VersionArgument va = getVersionArgument();
+    assert va.isVersionNumArgument();
+    
+    TypeDecl type = getSolution();
+    return new TypeAccess(((TypeAccess) getTypeAccess()).getPackage(), type.getID() + "_v" + type.version());
+  }
+
+  eq ParVersionTypeAccess.compileInstanceAccess() = getTypeAccess().compileAccess();
 
   syn nta Stmt Stmt.compileStmt() = treeCopy();
 
@@ -506,28 +554,29 @@ aspect Generation {
 
   eq Access.compileExpr() = compileAccess();
 
+  /*
   eq ClassInstanceExpr.compileExpr() {
     Access toCompile = getAccess();
 
     List<Expr> argList = new List();
-    if (getAccess() instanceof ParVersionTypeAccess) {
+    if (getAccess().isParVersionTypeAccess()) {
       ParVersionTypeAccess typeAccess = (ParVersionTypeAccess) getAccess();
 
       TypeDecl compileType = program().typeMap.get(new Integer(model().evaluate(getAccess().solverConst, false).toString()));
-      assert compileType instanceof GenericVersionClassDecl;
+      assert compileType.isGenericVersionClassDecl();
       GenericVersionClassDecl compileClass = (GenericVersionClassDecl) compileType;
 
       for (int i = 0; i < typeAccess.getNumVersionArgument(); i++) {
         VersionArgument va = typeAccess.getVersionArgument(i);
         VersionVariable vv = compileClass.getVersionVariable(i);
         TypeAccess compileAccess = vv.typeAccess();
-        if (va instanceof VersionNumArgument) {
+        if (va.isVersionNumArgument()) {
           argList = argList.add(new ClassInstanceExpr(
             new TypeAccess(compileAccess.getPackage(),
                            compileAccess.getID() + "_v" + va.getID() + "_Factory"),
             new List()
           ));
-        } else if (va instanceof VersionVarArgument) {
+        } else if (va.isVersionVarArgument()) {
           argList = argList.add(new VarAccess(va.getID()));
         }
       }
@@ -539,11 +588,15 @@ aspect Generation {
       argList = argList.add(arg.compileExpr());
     }
 
-    if (toCompile instanceof VersionTypeAccess) {
+    Access access = toCompile.compileAccess();
+
+    if (toCompile.isVersionTypeAccess()) {
       VersionTypeAccess typeAccess = (VersionTypeAccess) toCompile;
       VersionArgument va = typeAccess.getVersionArgument();
       
-      if (va instanceof VersionVarArgument) {
+      if (va.isVersionNumArgument()) {
+        access = typeAccess.getTypeAccess().compileAccess();
+      } else if (va.isVersionVarArgument()) {
         Access makeCall = new MethodAccess("make", argList);
         return new Dot(
           new VarAccess(va.getID()),
@@ -551,7 +604,53 @@ aspect Generation {
       }
     }
 
-    return new ClassInstanceExpr(toCompile.compileAccess(), argList);
+    return new ClassInstanceExpr(access, argList);
+  }
+  */
+
+  eq ClassInstanceExpr.compileExpr() {
+    Access toCompile = getAccess();
+    List<Expr> argList = new List();
+
+    if (toCompile.isParVersionTypeAccess()) {
+      TypeDecl compileType = program().typeMap
+        .get(new Integer(model().evaluate(getAccess().solverConst, false).toString()));
+      assert compileType.isGenericVersionClassDecl();
+      GenericVersionClassDecl compileClass = (GenericVersionClassDecl) compileType;
+
+      ParVersionTypeAccess typeAccess = (ParVersionTypeAccess) toCompile;
+
+      for (int i = 0; i < typeAccess.getNumVersionArgument(); i++) {
+        VersionArgument va = typeAccess.getVersionArgument(i);
+        VersionVariable vv = compileClass.getVersionVariable(i);
+        TypeAccess compileAccess = vv.typeAccess();
+        if (va.isVersionNumArgument()) {
+          argList = argList.add(new ClassInstanceExpr(
+            new TypeAccess(compileAccess.getPackage(), compileAccess.getID() + "_v" + va.getID() + "_Factory"),
+            new List()));
+        } else {
+          argList = argList.add(new VarAccess(va.getID()));
+        }
+      }
+
+      toCompile = typeAccess.getTypeAccess();
+    }
+
+    for (Expr arg: getArgList()) {
+      argList = argList.add(arg.compileExpr());
+    }
+
+    if (toCompile.isVersionTypeAccess()) {
+      VersionTypeAccess typeAccess = (VersionTypeAccess) toCompile;
+      VersionArgument va = typeAccess.getVersionArgument();
+      if (va.isVersionVarArgument()) {
+        return new Dot(new VarAccess(va.getID()), new MethodAccess("make", argList));
+      }
+    }
+
+    Access access = toCompile.compileInstanceAccess();
+
+    return new ClassInstanceExpr(access, argList); 
   }
 
   eq AssignSimpleExpr.compileExpr()
@@ -571,7 +670,7 @@ aspect Generation {
     List<ParameterDeclaration> params = new List();
     List<Expr> argList = new List();
 
-    if (hostType() instanceof GenericVersionClassDecl) {
+    if (hostType().isGenericVersionClassDecl()) {
       GenericVersionClassDecl host = (GenericVersionClassDecl) hostType();
       for (int i = 0; i < host.getNumVersionVariable(); i++) {
         VersionVariable v_i = host.getVersionVariable(i);
@@ -616,7 +715,7 @@ aspect Generation {
   eq ConstructorDecl.compileInterfaceFactory() {
     List<ParameterDeclaration> params = new List();
 
-    if (hostType() instanceof GenericVersionClassDecl) {
+    if (hostType().isGenericVersionClassDecl()) {
       GenericVersionClassDecl host = (GenericVersionClassDecl) hostType();
       for (int i = 0; i < host.getNumVersionVariable(); i++) {
         VersionVariable v_i = host.getVersionVariable(i);
@@ -655,7 +754,9 @@ aspect Generation {
       ps = ps.add(p.treeCopy());
     }
 
-    List<Stmt> stmtList = new List().add(new ReturnStmt(new NullLiteral("null")));
+    List<Stmt> stmtList = type().isVoid()
+      ? new List().add(new ReturnStmt())
+      : new List().add(new ReturnStmt(new NullLiteral("null")));
 
     return new MethodDecl(
       getModifiers(),

--- a/batakjava/constraint/Generation.jrag
+++ b/batakjava/constraint/Generation.jrag
@@ -61,6 +61,11 @@ aspect ConstraintVariable {
     return Collections.singleton(solverConst);
   }
   
+  public TypeDecl Expr.getSolution() {
+    assert solverConst != null;
+    return program().typeMap.get(new Integer(model().evaluate(solverConst, false).toString()));
+  }
+
 }
 
 aspect ConstraintGeneration {
@@ -171,8 +176,8 @@ aspect ConstraintGeneration {
   eq ClassInstanceExpr.constraint() {
     Formula f = new Formula();
     // TODO: remove this temporary fix
-    if (getAccess() instanceof VersionTypeAccess &&
-        ((VersionTypeAccess) getAccess()).getVersionArgument() instanceof VersionVarArgument) {
+    if (getAccess().isVersionTypeAccess() &&
+        ((VersionTypeAccess) getAccess()).getVersionArgument().isVersionVarArgument()) {
       return f;
     }
     for (TypeDecl type: typeSet()) {

--- a/batakjava/frontend/InnerClasses.jrag
+++ b/batakjava/frontend/InnerClasses.jrag
@@ -14,7 +14,7 @@ aspect InnerClassesBatak {
 
   public boolean TypeDecl.hasLocalMethod(MethodDecl decl) {
     for (BodyDecl b: getBodyDeclList()) {
-      if (b instanceof MethodDecl) {
+      if (b.isMethodDecl()) {
         MethodDecl m = (MethodDecl) b;
         if (m.signature().equals(decl.signature())) {
           return true;

--- a/batakjava/frontend/LookupMethod.jrag
+++ b/batakjava/frontend/LookupMethod.jrag
@@ -17,6 +17,10 @@ aspect LookupMethod {
 
 aspect MethodDecl {
 
+  syn boolean BodyDecl.isMethodDecl() = false;
+
+  eq MethodDecl.isMethodDecl() = true;
+  
   syn Optional<Formula> MethodAccess.verApplicableAndAccessible(MethodDecl m) {
     if (m.getNumParameter() != getNumArg()) {
       return Optional.empty();
@@ -57,7 +61,7 @@ aspect MemberMethods {
     }
     ArrayList<MethodDecl> methods = new ArrayList<MethodDecl>(getNumBodyDecl());
     for (BodyDecl decl : getBodyDeclList()) {
-      if (decl instanceof MethodDecl) {
+      if (decl.isMethodDecl()) {
         methods.add((MethodDecl) decl);
       }
     }

--- a/batakjava/frontend/LookupVariable.jrag
+++ b/batakjava/frontend/LookupVariable.jrag
@@ -99,7 +99,6 @@ aspect VersionVariableScope {
       set = set.add(a);
     }
 
-    // LATER: method body
     if (hasBlock()) {
       for (Access a: getBlock().blockBoundSet(v, visited)) {
         set = set.add(a);
@@ -178,6 +177,32 @@ aspect VersionVariableScope {
   eq Block.boundSet(VersionVariable v, SimpleSet<TypeDecl> visited) = blockBoundSet(v, visited);
 
   eq ExprStmt.boundSet(VersionVariable v, SimpleSet<TypeDecl> visited) = getExpr().boundSet(v, visited);
+
+  eq VarDeclStmt.boundSet(VersionVariable v, SimpleSet<TypeDecl> visited) {
+    SimpleSet<Access> set = emptySet();
+    for (Access a: getTypeAccess().boundSet(v, visited)) {
+      set = set.add(a);
+    }
+    for (VariableDeclarator d: getDeclaratorList()) {
+      for (Access a: d.boundSet(v, visited)) {
+        set = set.add(a);
+      }
+    }
+    return set;
+  }
+
+  syn SimpleSet<Access> Declarator.boundSet(VersionVariable v, SimpleSet<TypeDecl> visited) {
+    SimpleSet<Access> set = emptySet();
+    for (Access a: getTypeAccess().boundSet(v, visited)) {
+      set = set.add(a);
+    }
+    if (hasInit()) {
+      for (Access a: getInit().boundSet(v, visited)) {
+        set = set.add(a);
+      }
+    }
+    return set;
+  }
 
   syn boolean VersionArgument.isBound(VersionVariable v) = false;
 

--- a/batakjava/frontend/ResolveAmbiguousNames.jrag
+++ b/batakjava/frontend/ResolveAmbiguousNames.jrag
@@ -1,0 +1,11 @@
+aspect AccessTypes {
+
+  syn boolean Access.isVersionTypeAccess() = false;
+  
+  eq VersionTypeAccess.isVersionTypeAccess() = true;
+
+  syn boolean Access.isParVersionTypeAccess() = false;
+
+  eq ParVersionTypeAccess.isParVersionTypeAccess() = true;
+
+}

--- a/batakjava/frontend/TypeAnalysis.jrag
+++ b/batakjava/frontend/TypeAnalysis.jrag
@@ -52,7 +52,22 @@ aspect TypeSet {
 
   eq TypeAccess.typeSet() = declSet();
 
-  eq VersionTypeAccess.typeSet() = getTypeAccess().typeSet();
+  // eq VersionTypeAccess.typeSet() = getTypeAccess().typeSet();
+
+  eq VersionTypeAccess.typeSet() {
+    SimpleSet<TypeDecl> typeSet0 = getTypeAccess().typeSet();
+    VersionArgument arg = getVersionArgument();
+    if (arg.isVersionNumArgument()) {
+      SimpleSet<TypeDecl> typeSet = emptySet();
+      for (TypeDecl type: typeSet0) {
+        if (type.version().equals(arg.getID())) {
+          typeSet = typeSet.add(type);
+        }
+      }
+      return typeSet;
+    }
+    return typeSet0;
+  }
 
   eq ParVersionTypeAccess.typeSet() {
     SimpleSet<TypeDecl> typeSet = emptySet();
@@ -444,5 +459,17 @@ aspect NestedTypes {
   inh TypeDecl VersionVariable.hostType();
 
   eq GenericVersionClassDecl.getVersionVariable(int i).hostType() = hostType();
+
+}
+
+aspect TypeAnalysis {
+
+  syn boolean TypeDecl.isVersionClassDecl() = false;
+
+  eq VersionClassDecl.isVersionClassDecl() = true;
+
+  syn boolean TypeDecl.isGenericVersionClassDecl() = false;
+
+  eq GenericVersionClassDecl.isGenericVersionClassDecl() = true;
 
 }

--- a/batakjava/frontend/Version.jrag
+++ b/batakjava/frontend/Version.jrag
@@ -83,6 +83,10 @@ aspect Version {
 
   eq VersionNumArgument.isVersionNumArgument() = true;
 
+  syn boolean VersionArgument.isVersionVarArgument() = false;
+
+  eq VersionVarArgument.isVersionVarArgument() = true;
+
   syn lazy boolean ParVersionTypeAccess.hasVersionNumArgument() {
     for (int i = 0; i < getNumVersionArgument(); i++) {
       if (getVersionArgument(i).isVersionNumArgument()) {

--- a/tests/hash_02/1/Hash.java
+++ b/tests/hash_02/1/Hash.java
@@ -1,0 +1,14 @@
+public class Hash ver 1 {
+  public Hash() {}
+  public HashValue#1# mkHash(String s) {
+    if (s.equals("a")) {
+      return new HashValue#1#(1);
+    }
+    return new HashValue#1#(0);
+  }
+  // if int is the class HashValue, we can control the version
+  // by making sure that it is the same version as this class
+  public boolean match(String s, HashValue#1# h) {
+    return this.mkHash(s).equals(h);
+  }
+}

--- a/tests/hash_02/1/HashValue.java
+++ b/tests/hash_02/1/HashValue.java
@@ -1,0 +1,12 @@
+public class HashValue ver 1 {
+  private int val;
+  public HashValue(int val) {
+    this.val = val;
+  }
+  public int getVal() {
+    return this.val;
+  }
+  public boolean equals(HashValue#1# o) {
+    return this.getVal() == o.getVal();
+  }
+}

--- a/tests/hash_02/2/Hash.java
+++ b/tests/hash_02/2/Hash.java
@@ -1,0 +1,33 @@
+public class Hash ver 2 {
+  public Hash() {}
+  public HashValue#2# mkHash(String s) {
+    if (s.equals("a")) {
+      return new HashValue#2#(-1);
+    }
+    return new HashValue#2#(0);
+  }
+  public boolean match(String s, HashValue#2# h) {
+    return this.mkHash(s).equals(h);
+  }
+}
+
+/**
+ * Using type parameters, work on this!
+ * 
+ * interface HashAlgorithm { }
+ * 
+ * interface CRC32 extends HashAlgorithm { }
+ * 
+ * interface SHA extends HashAlgorithm { }
+ * 
+ * public class HashValue ver 2 <T implements HashAlgorithm> {
+ *   ...
+ * }
+ * 
+ * public class Hash ver 2 <T extends CRC32> {
+ *   public HashValue<T> mkHash(String s) {
+ *     ...
+ *     return new HashValue<T>(0);
+ *   }
+ * }
+ */

--- a/tests/hash_02/2/HashValue.java
+++ b/tests/hash_02/2/HashValue.java
@@ -1,0 +1,12 @@
+public class HashValue ver 2 {
+  private int val;
+  public HashValue(int val) {
+    this.val = val;
+  }
+  public int getVal() {
+    return this.val;
+  }
+  public boolean equals(HashValue#2# o) {
+    return this.getVal() == o.getVal();
+  }
+}

--- a/tests/hash_02/Dir.java
+++ b/tests/hash_02/Dir.java
@@ -1,0 +1,18 @@
+public class Dir ver 1 «V,W» {
+  public String[] getFiles() {
+    String[] files = new String[1];
+    files[0] = "a";
+    return files;
+  }
+  public boolean exists(HashValue#V# h) {
+    String[] fs = this.getFiles();
+    // we can also reinforce hash with a specific version
+    Hash#W# hash = new Hash#W#();
+    for (int i = 0; i < fs.length; i++) {
+      if (hash.match(fs[i], h)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/tests/hash_02/Test.java
+++ b/tests/hash_02/Test.java
@@ -1,0 +1,13 @@
+public class Test {
+  public static void main(String[] args) {
+    String s = args[0];
+    Hash hash = new Hash();
+    HashValue digest = hash.mkHash(s);
+    Dir dir = new Dir();
+    if (dir.exists(digest)) {
+      System.out.println("found");
+    } else {
+      System.err.println("not found");
+    }
+  }
+}

--- a/tests/hash_02/build.sh
+++ b/tests/hash_02/build.sh
@@ -1,0 +1,5 @@
+#/bin/sh
+
+rm -rf tests/hash_02/class
+mkdir tests/hash_02/class
+java -jar pbatakjava.jar tests/hash_02/1/*.java tests/hash_02/2/*.java tests/hash_02/Dir.java -d tests/hash_02/class

--- a/tests/reference/compilable-hash_01-4c2da9c.json
+++ b/tests/reference/compilable-hash_01-4c2da9c.json
@@ -4,7 +4,7 @@
     "infile": "tests/hash_01/build.sh",
     "infile_hash": "a1f70bf2ef2682f6c9838a4e9fc98bb68207a94fe0419d4f634ff4fa",
     "stdout": "compilable-hash_01-4c2da9c.stdout",
-    "stdout_hash": "502237a3142b2c73d71f4d11fac7c0f093a7a5aea0b9639ba9162bde",
+    "stdout_hash": "a9558aa1264c18bf5c888973636c172e2428aa6d43d13f2404e16d2a",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/compilable-hash_01-4c2da9c.stderr
+++ b/tests/reference/compilable-hash_01-4c2da9c.stderr
@@ -1,0 +1,3 @@
+tests/hash_01/2/HashValue.java:0: error: return value must be an instance of boolean which null is not
+tests/hash_01/1/HashValue.java:0: error: return value must be an instance of boolean which null is not
+tests/hash_01/Test.java:0: error: can not assign variable digest of type HashValue_v1 a value of type HashValue

--- a/tests/reference/compilable-hash_02-a0a2bcd.json
+++ b/tests/reference/compilable-hash_02-a0a2bcd.json
@@ -1,0 +1,11 @@
+{
+    "basename": "compilable-hash_02-a0a2bcd",
+    "cmd": "{infile}",
+    "infile": "tests/hash_02/build.sh",
+    "infile_hash": "fec4d6709bfd9781f16fb290dee0dc55eea88f36e670def985d0e3a5",
+    "stdout": "compilable-hash_02-a0a2bcd.stdout",
+    "stdout_hash": "3a8951ca76fd03cc677f5f60e68cd9f5007818ee0831d5fd4bb80166",
+    "stderr": null,
+    "stderr_hash": null,
+    "returncode": 0
+}

--- a/tests/reference/compilable-hash_02-a0a2bcd.stdout
+++ b/tests/reference/compilable-hash_02-a0a2bcd.stdout
@@ -60,9 +60,13 @@ public interface Hash {
 }
 
 public interface Hash_Factory {
+  public Hash make();
 }
 
 public class Hash_v1 implements Hash {
+  public Hash_v1() {
+  }
+
   public HashValue mkHash(String s) {
     if (s.equals("a")) {
       return new HashValue_v1(1);
@@ -76,9 +80,15 @@ public class Hash_v1 implements Hash {
 }
 
 public class Hash_v1_Factory implements Hash_Factory {
+  public Hash make() {
+    return new Hash_v1();
+  }
 }
 
 public class Hash_v2 implements Hash {
+  public Hash_v2() {
+  }
+
   public HashValue mkHash(String s) {
     if (s.equals("a")) {
       return new HashValue_v2(-1);
@@ -92,9 +102,25 @@ public class Hash_v2 implements Hash {
 }
 
 public class Hash_v2_Factory implements Hash_Factory {
+  public Hash make() {
+    return new Hash_v2();
+  }
 }
 
-public class Dir {
+public interface Dir {
+  public String[] getFiles();
+
+  public boolean exists(HashValue h);
+}
+
+public interface Dir_Factory {
+}
+
+public class Dir_v1 implements Dir {
+  public HashValue_Factory V;
+
+  public Hash_Factory W;
+
   public String[] getFiles() {
     String[] files = new String[1];
     files[0] = "a";
@@ -103,7 +129,7 @@ public class Dir {
 
   public boolean exists(HashValue h) {
     String[] fs = this.getFiles();
-    Hash hash = new Hash_v1();
+    Hash hash = W.make();
     for (int i = 0; i < fs.length; i++) {
       if (hash.match(fs[i], h)) {
         return true;
@@ -113,16 +139,5 @@ public class Dir {
   }
 }
 
-public class Test {
-  public static void main(String[] args) {
-    String s = args[0];
-    Hash hash = new Hash_v1();
-    HashValue digest = hash.mkHash(s);
-    Dir dir = new Dir();
-    if (dir.exists(digest)) {
-      System.out.println("found");
-    } else {
-      System.err.println("not found");
-    }
-  }
+public class Dir_v1_Factory implements Dir_Factory {
 }

--- a/tests/reference/compilable-instance_01-7040b8e.json
+++ b/tests/reference/compilable-instance_01-7040b8e.json
@@ -4,7 +4,7 @@
     "infile": "tests/instance_01/build.sh",
     "infile_hash": "9bcf3e27e560ccd948871dca814364ccb6a295f6b484f869005d7a10",
     "stdout": "compilable-instance_01-7040b8e.stdout",
-    "stdout_hash": "f3c892929fe3d094c42bc9b77545e4fd1518d01764b94b12781cbca5",
+    "stdout_hash": "aa603e78356ef629aabbdce6ed09bf1eec025b903b79af25af8c84f2",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/compilable-instance_01-7040b8e.stdout
+++ b/tests/reference/compilable-instance_01-7040b8e.stdout
@@ -48,7 +48,7 @@ public interface Test_Factory {
 
 public class Test_v1 implements Test {
   public static void main(String[] args) {
-    Point_v1 p = new Point_v1(1, 1);
+    Point p = new Point_v1(1, 1);
   }
 }
 

--- a/tests/reference/compilable-instance_02-13e2b6b.json
+++ b/tests/reference/compilable-instance_02-13e2b6b.json
@@ -4,7 +4,7 @@
     "infile": "tests/instance_02/build.sh",
     "infile_hash": "7fa632ebf7d6a77e99bbf397e76e1f925d037763db9702033e35f688",
     "stdout": "compilable-instance_02-13e2b6b.stdout",
-    "stdout_hash": "a4eb09e793950c018ba13c27c88841ba84facf73511ef3133319d2ee",
+    "stdout_hash": "7628dfdb4bb8f6a4f74435693cc6b01fbc9ac68687a70ec51e4b2e5c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/compilable-instance_02-13e2b6b.stdout
+++ b/tests/reference/compilable-instance_02-13e2b6b.stdout
@@ -78,10 +78,10 @@ public interface Test_Factory {
 
 public class Test_v1 implements Test {
   public static void main(String[] args) {
-    Line_v1 l1 = new Line_v1(new Point_v1_Factory(), new Point_v1_Factory(), new Point_v1(1, 1), new Point_v1(2, 2));
-    Line_v1 l2 = new Line_v1(new Point_v2_Factory(), new Point_v2_Factory(), new Point_v2(1, 1), new Point_v2(2, 2));
-    Line_v1 l3 = new Line_v1(new Point_v1_Factory(), new Point_v2_Factory(), new Point_v1(1, 1), new Point_v2(2, 2));
-    Line_v1 l4 = new Line_v1(new Point_v2_Factory(), new Point_v1_Factory(), new Point_v2(1, 1), new Point_v1(2, 2));
+    Line l1 = new Line_v1(new Point_v1_Factory(), new Point_v1_Factory(), new Point_v1(1, 1), new Point_v1(2, 2));
+    Line l2 = new Line_v1(new Point_v2_Factory(), new Point_v2_Factory(), new Point_v2(1, 1), new Point_v2(2, 2));
+    Line l3 = new Line_v1(new Point_v1_Factory(), new Point_v2_Factory(), new Point_v1(1, 1), new Point_v2(2, 2));
+    Line l4 = new Line_v1(new Point_v2_Factory(), new Point_v1_Factory(), new Point_v2(1, 1), new Point_v1(2, 2));
   }
 }
 

--- a/tests/reference/compilable-instance_03-d081460.json
+++ b/tests/reference/compilable-instance_03-d081460.json
@@ -4,7 +4,7 @@
     "infile": "tests/instance_03/build.sh",
     "infile_hash": "abf159e9e18f849984fa106090fd5f92a820c2e96110f69d0850172b",
     "stdout": "compilable-instance_03-d081460.stdout",
-    "stdout_hash": "0ddfb81b9be3831b130e07769e661eb657613c2924aec9b9dd35fde9",
+    "stdout_hash": "1b63061c8375b2e0bcfda6c7071aa94f3ecbb22b9802c641e483c6c5",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/compilable-instance_03-d081460.stdout
+++ b/tests/reference/compilable-instance_03-d081460.stdout
@@ -1,5 +1,6 @@
 
 public interface Point {
+  public void m();
 }
 
 public interface Point_Factory {
@@ -35,6 +36,10 @@ public class Point_v2 implements Point {
   public Point_v2(int x, int y) {
     this.x = x;
     this.y = y;
+  }
+
+  public void m() {
+    return;
   }
 }
 
@@ -82,9 +87,9 @@ public interface Test_Factory {
 
 public class Test_v1 implements Test {
   public static void main(String[] args) {
-    Point_v1 p1 = new Point_v1(1, 1);
+    Point p1 = new Point_v1(1, 1);
     p1.m();
-    Line_v1 l1 = new Line_v1(new Point_v1_Factory(), new Point_v2_Factory(), p1, new Point_v2(2, 2));
+    Line l1 = new Line_v1(new Point_v1_Factory(), new Point_v2_Factory(), p1, new Point_v2(2, 2));
   }
 }
 

--- a/tests/reference/compilable-instance_04-a4572a3.json
+++ b/tests/reference/compilable-instance_04-a4572a3.json
@@ -4,7 +4,7 @@
     "infile": "tests/instance_04/build.sh",
     "infile_hash": "09977858e1dc340ad8e47fdee8a723605a99977e6468e5898531aafa",
     "stdout": "compilable-instance_04-a4572a3.stdout",
-    "stdout_hash": "91a2d316671ec60ee9866ab14cd310e425f9aaa9b070076bb6f9d7aa",
+    "stdout_hash": "2687e1d549f307e2dac613dcac824575ef1e37975cb411c70cf1c78c",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/compilable-instance_04-a4572a3.stdout
+++ b/tests/reference/compilable-instance_04-a4572a3.stdout
@@ -77,7 +77,7 @@ public class Point_v2_Factory implements Point_Factory {
 }
 
 public interface Line {
-  public Line_v1 update(Point_Factory Y, Point p);
+  public Line update(Point_Factory Y, Point p);
 
   public void update(Color_Factory Y);
 }
@@ -102,7 +102,7 @@ class Line_v1 implements Line {
     this.p2 = p2;
   }
 
-  public Line_v1 update(Point_Factory Y, Point p) {
+  public Line update(Point_Factory Y, Point p) {
     return new Line_v1(V, Y, p1, p);
   }
 

--- a/tests/reference/compilable-method_01-e36e71e.json
+++ b/tests/reference/compilable-method_01-e36e71e.json
@@ -4,7 +4,7 @@
     "infile": "tests/method_01/build.sh",
     "infile_hash": "b4ec96e3e1a1f172940e50aebe288067ea82840efd33f2fdb870ae55",
     "stdout": "compilable-method_01-e36e71e.stdout",
-    "stdout_hash": "c1d048b875cffbb83664372ab36b809860831028512eba68ded95c4e",
+    "stdout_hash": "e1d5e4db2aa0a32741ac9f9fa97551d32c9065f87df261de9c4bb538",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/compilable-method_01-e36e71e.stdout
+++ b/tests/reference/compilable-method_01-e36e71e.stdout
@@ -41,7 +41,7 @@ public class Point_v2_Factory implements Point_Factory {
 }
 
 public interface Line {
-  public Line_v1 update(Point_Factory Y, Point p);
+  public Line update(Point_Factory Y, Point p);
 }
 
 public interface Line_Factory {
@@ -64,7 +64,7 @@ public class Line_v1 implements Line {
     this.p2 = p2;
   }
 
-  public Line_v1 update(Point_Factory Y, Point p) {
+  public Line update(Point_Factory Y, Point p) {
     return new Line_v1(V, Y, p1, p);
   }
 }
@@ -83,8 +83,8 @@ public interface Test_Factory {
 
 public class Test_v1 implements Test {
   public static void main(String[] args) {
-    Line_v1 l1 = new Line_v1(new Point_v1_Factory(), new Point_v2_Factory(), new Point_v1(1, 1), new Point_v2(2, 2));
-    Line_v1 l2 = l1.update(new Point_v2_Factory(), new Point_v2(2, 2));
+    Line l1 = new Line_v1(new Point_v1_Factory(), new Point_v2_Factory(), new Point_v1(1, 1), new Point_v2(2, 2));
+    Line l2 = l1.update(new Point_v2_Factory(), new Point_v2(2, 2));
   }
 }
 

--- a/tests/reference/compilable-method_02-93af45d.json
+++ b/tests/reference/compilable-method_02-93af45d.json
@@ -4,7 +4,7 @@
     "infile": "tests/method_02/build.sh",
     "infile_hash": "b503857a39d45d5c3d0d116497c28e984b3e4f2101d25db9fa3cf7fb",
     "stdout": "compilable-method_02-93af45d.stdout",
-    "stdout_hash": "12c9df55431912cbd65804c8ba2676c7602e379c64cb6eac94d6718f",
+    "stdout_hash": "9433697d4a4e2f4cb39c5f73a89128422748ce902319100f065130fb",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/compilable-method_02-93af45d.stdout
+++ b/tests/reference/compilable-method_02-93af45d.stdout
@@ -50,7 +50,7 @@ public class Point_v2_Factory implements Point_Factory {
 }
 
 public interface Line {
-  public Line_v1 rotate(Point_Factory Y);
+  public Line rotate(Point_Factory Y);
 }
 
 public interface Line_Factory {
@@ -73,7 +73,7 @@ public class Line_v1 implements Line {
     this.p2 = p2;
   }
 
-  public Line_v1 rotate(Point_Factory Y) {
+  public Line rotate(Point_Factory Y) {
     return new Line_v1(V, Y, p1, p2.inverse(Y));
   }
 }
@@ -92,8 +92,8 @@ public interface Test_Factory {
 
 public class Test_v1 implements Test {
   public static void main(String[] args) {
-    Line_v1 l1 = new Line_v1(new Point_v2_Factory(), new Point_v2_Factory(), new Point_v2(2, 2), new Point_v2(1, 1));
-    Line_v1 l2 = l1.rotate(new Point_v1_Factory());
+    Line l1 = new Line_v1(new Point_v2_Factory(), new Point_v2_Factory(), new Point_v2(2, 2), new Point_v2(1, 1));
+    Line l2 = l1.rotate(new Point_v1_Factory());
   }
 }
 

--- a/tests/reference/compilable-method_03-269c346.json
+++ b/tests/reference/compilable-method_03-269c346.json
@@ -4,7 +4,7 @@
     "infile": "tests/method_03/build.sh",
     "infile_hash": "007d191c26263f17113537fa389af36ecd8ce948604c284f3b3b9e67",
     "stdout": "compilable-method_03-269c346.stdout",
-    "stdout_hash": "aa36e870fcd7740dd636844477af4983b96e87bdb93187a2285bd2e7",
+    "stdout_hash": "5945fbaca75fdb24b91c8532e6697eef77d820c5123bfe59cb854962",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/compilable-method_03-269c346.stdout
+++ b/tests/reference/compilable-method_03-269c346.stdout
@@ -50,7 +50,7 @@ public class Point_v2_Factory implements Point_Factory {
 }
 
 public interface Line {
-  public Line_v1 rotate(Point_Factory Y);
+  public Line rotate(Point_Factory Y);
 }
 
 public interface Line_Factory {
@@ -73,7 +73,7 @@ public class Line_v1 implements Line {
     this.p2 = p2;
   }
 
-  public Line_v1 rotate(Point_Factory Y) {
+  public Line rotate(Point_Factory Y) {
     return null;
   }
 }
@@ -100,7 +100,7 @@ public class Line_v2 implements Line {
     this.p2 = p2;
   }
 
-  public Line_v1 rotate(Point_Factory Y) {
+  public Line rotate(Point_Factory Y) {
     return new Line_v1(V, Y, p1, p2.inverse(Y));
   }
 }
@@ -119,8 +119,8 @@ public interface Test_Factory {
 
 public class Test_v1 implements Test {
   public static void main(String[] args) {
-    Line_v2 l1 = new Line_v2(new Point_v2_Factory(), new Point_v2_Factory(), new Point_v2(2, 2), new Point_v2(1, 1));
-    Line_v1 l2 = l1.rotate(new Point_v1_Factory());
+    Line l1 = new Line_v2(new Point_v2_Factory(), new Point_v2_Factory(), new Point_v2(2, 2), new Point_v2(1, 1));
+    Line l2 = l1.rotate(new Point_v1_Factory());
   }
 }
 

--- a/tests/reference/compilable-subtype_01-4d2c2ed.json
+++ b/tests/reference/compilable-subtype_01-4d2c2ed.json
@@ -4,7 +4,7 @@
     "infile": "tests/subtype_01/build.sh",
     "infile_hash": "75687d00d82803ba735d04c9e5dd0aa532fa06b68b45ea6aec4b3598",
     "stdout": "compilable-subtype_01-4d2c2ed.stdout",
-    "stdout_hash": "c6ff2ad2d2fdaa29ad4b85fee07695a55322bf2f5bf6f39792ad2fe0",
+    "stdout_hash": "9090b7c4c5ad0ab0e03dae9d0b66fc5b486b19a2799b7416945bb80b",
     "stderr": null,
     "stderr_hash": null,
     "returncode": 0

--- a/tests/reference/compilable-subtype_01-4d2c2ed.stdout
+++ b/tests/reference/compilable-subtype_01-4d2c2ed.stdout
@@ -70,7 +70,7 @@ public class ColoredPoint_v1_Factory implements ColoredPoint_Factory {
 
 public class Test {
   public static void main(String[] args) {
-    Point_v1 p1 = new Point_v1(1, 2);
-    Point_v1 p2 = new ColoredPoint_v1(1, 2, 3, 4, 5);
+    Point p1 = new Point_v1(1, 2);
+    Point p2 = new ColoredPoint_v1(1, 2, 3, 4, 5);
   }
 }

--- a/tests/tests.toml
+++ b/tests/tests.toml
@@ -59,6 +59,10 @@ filename = "tests/hash_01/build.sh"
 compilable = true
 
 [[test]]
+filename = "tests/hash_02/build.sh"
+compilable = true
+
+[[test]]
 filename = "tests/error_01/build.sh"
 error = true
 


### PR DESCRIPTION
To allow access from polymorphic to monomorphic definitions in Java, all multi-version class instances can't be fixed. The Hash example demonstrates this.